### PR TITLE
Fix Numpy warnings, don't require cupy/symao

### DIFF
--- a/mastsel/mavisLO.py
+++ b/mastsel/mavisLO.py
@@ -266,8 +266,8 @@ class MavisLO(object):
             self.mItcomplex = Integrator(cp, cp.complex64, '')
             self.platformlib = gpulib
         else:
-            self.mIt = Integrator(np, np.float, '')
-            self.mItcomplex = Integrator(np, np.complex, '')
+            self.mIt = Integrator(np, float, '')
+            self.mItcomplex = Integrator(np, complex, '')
             self.platformlib = cpulib
 
 

--- a/mastsel/mavisUtilities.py
+++ b/mastsel/mavisUtilities.py
@@ -116,7 +116,7 @@ def congrid(a, newdims, method='linear', centre=False, minusone=False):
             dimlist.append((old[i] - m1) / (newdims[i] - m1)
                            * (base + ofs) - ofs)
         # specify old dims
-        olddims = [np.arange(i, dtype=np.float) for i in list(a.shape)]
+        olddims = [np.arange(i, dtype=float) for i in list(a.shape)]
 
         # first interpolation - for ndims = any
         mint = scipy.interpolate.interp1d(

--- a/notebooks/MAVIS.ipynb
+++ b/notebooks/MAVIS.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "# Field_size = 1024*4\n",
     "# defaultArrayBackend=np\n",
-    "# f2 = Field(SensingWavelength_HO, Field_size, 32*4, 'm', np, np.float)\n",
+    "# f2 = Field(SensingWavelength_HO, Field_size, 32*4, 'm', np, float)\n",
     "# f2.setAsTelescopeMask(4,0)"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(name='mastsel',
           "scipy",
           "astropy",
           "matplotlib",
-          "cupy",
-          "symao",
-      ]
+          # "symao",
+      ],
+      extras_require={
+          "gpu": ["cupy"],
+      },
       )


### PR DESCRIPTION
- Using `np.float` or `np.complex` is deprecated in recent Numpy versions
- cupy cannot be installed with pip (from source) on a machine without cuda-toolkit. It's already optional in the code so I just made its installation optional. It can be installed with `pip install -e .[cupy]`
- symao is not on PyPI so cannot be installed automatically as a dependency.